### PR TITLE
added external quick links to token detail page

### DIFF
--- a/apps/web/src/app/tokens/[mintAddress]/page.tsx
+++ b/apps/web/src/app/tokens/[mintAddress]/page.tsx
@@ -4,6 +4,7 @@ import { CommentSection } from '@/components/comments/CommentSection';
 import { SolscanButton } from '@/components/SolscanButton';
 import { TokenImage } from '@/components/tokens/TokenImage';
 import { TokenStats } from '@/components/tokens/TokenStats';
+import { TokenExternalLinks } from "@/components/tokens/TokenExternalLinks";
 import { WatchlistButton } from '@/components/tokens/WatchlistButton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -28,6 +29,7 @@ import {
   Shield,
   Sparkles,
   Twitter,
+  ExternalLink
 } from 'lucide-react';
 import Link from 'next/link';
 import { notFound, usePathname, useRouter } from 'next/navigation';
@@ -748,6 +750,29 @@ export default function Page({ params, commentId }: PageProps) {
                     </div>
                   )}
                 </CardContent>
+
+              </Card>
+            </div>
+            {/* External Links */}
+            <div className='relative group'>
+              <div className='absolute -inset-0.5 bg-gradient-to-r from-blue-500 to-blue-600 rounded-2xl blur opacity-25 group-hover:opacity-40 transition duration-300'></div>
+              <Card className='relative h-full bg-zinc-900/40 backdrop-blur-sm border-0 rounded-xl overflow-hidden'>
+                <div className='absolute inset-0 bg-gradient-to-br from-blue-600/5 to-blue-800/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300' />
+                <CardHeader className='pb-2 relative'>
+                  <div className='flex items-center mb-4'>
+                    <div className='h-10 w-10 rounded-xl bg-blue-500/10 flex items-center justify-center mr-4 group-hover:bg-blue-500/20 transition-colors duration-300'>
+                      <ExternalLink className='h-5 w-5 text-blue-400' />
+                    </div>
+                    <CardTitle className='text-xl font-semibold text-white'>
+                      External links
+                    </CardTitle>
+                  </div>
+                  <div className='w-full h-0.5 bg-gradient-to-r from-blue-500/20 to-transparent'></div>
+                </CardHeader>
+                <CardContent className='pt-2 pb-6'>
+                  <TokenExternalLinks tokenAddress={mintAddress} className="gap-0" />
+                </CardContent>
+
               </Card>
             </div>
           </div>

--- a/apps/web/src/components/tokens/TokenExternalLinks.tsx
+++ b/apps/web/src/components/tokens/TokenExternalLinks.tsx
@@ -1,0 +1,73 @@
+// components/ExternalLinks.tsx
+import Image from "next/image";
+import Link from 'next/link';
+
+const LINKS = [
+  {
+    name: "GMGN",
+    icon: "https://www.google.com/s2/favicons?domain=gmgn.ai",
+    url: (token: string) => `https://gmgn.ai/sol/token/${token}`,
+  },
+  {
+    name: "DEX Screener",
+    icon: "https://www.google.com/s2/favicons?domain=dexscreener.com",
+    url: (token: string) => `https://dexscreener.com/solana/${token}`,
+  },
+  {
+    name: "Birdeye",
+    icon: "https://www.google.com/s2/favicons?domain=birdeye.so",
+    url: (token: string) => `https://birdeye.so/token/${token}?chain=solana`,
+  },
+  {
+    name: "DexTools",
+    icon: "https://www.google.com/s2/favicons?domain=dextools.io",
+    url: (token: string) =>
+      `https://www.dextools.io/app/en/solana/pair-explorer/${token}`,
+  },
+  {
+    name: "GeckoTerminal",
+    icon: "https://www.google.com/s2/favicons?domain=geckoterminal.com",
+    url: (token: string) =>
+      `https://www.geckoterminal.com/solana/tokens/${token}`,
+  },
+  {
+    name: "Bubblemaps",
+    icon: "https://www.google.com/s2/favicons?domain=bubblemaps.io",
+    url: (token: string) =>
+      `https://app.bubblemaps.io/sol/token/${token}`,
+  },
+  {
+    name: "RugCheck",
+    icon: "https://www.google.com/s2/favicons?domain=rugcheck.xyz",
+    url: (token: string) => `https://rugcheck.xyz/tokens/${token}`,
+  }
+];
+
+type Props = {
+  tokenAddress: string;
+  className?: string;
+};
+
+export const TokenExternalLinks = ({ tokenAddress, className = "" }: Props) => {
+  return (
+    <div className={`flex flex-row flex-nowrap items-center gap-2 overflow-x-auto ${className}`}>
+      {LINKS.map(({ name, icon, url }) => (
+        <Link
+        href={url(tokenAddress)}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='flex items-center justify-center gap-2 w-8 h-8 bg-black-800/50 backdrop-blur-sm border border-zinc-700/30 rounded-lg hover:bg-zinc-700/50 hover:border-blue-500/30 transition-all duration-200'
+        title={name}>
+         <Image
+            src={icon}
+            alt={name}
+            width={16}
+            height={16}
+            className="rounded-sm"
+          />
+      </Link>
+      ))}
+    </div>
+  );
+};
+


### PR DESCRIPTION
This PR introduces a new reusable component called TokenExternalLinks that displays a compact row of external service icons (like DEX Screener, Birdeye, GeckoTerminal, etc.), each linking to the relevant page for a given token address.

Quick access: Users can jump directly to third-party analytics, charts, and verification tools without having to search manually.

Improved UX: Compact visual layout with recognizable icons keeps the UI clean and intuitive.

Modular & Reusable: The component accepts a tokenAddress prop and can be reused across different pages (e.g. token pages, listings, etc.)

Preview:
<img width="1183" alt="Screenshot 2025-04-11 at 11 38 31" src="https://github.com/user-attachments/assets/6171151f-9bbb-479f-83f8-2dc798054a98" />

